### PR TITLE
Fix hour12 function

### DIFF
--- a/yaya_base/shiori3.dic
+++ b/yaya_base/shiori3.dic
@@ -1920,7 +1920,7 @@ day     { GETTIME[2] }
 weekday { GETTIME[3] }
 hour    { GETTIME[4] }
 ampm    { if hour >= 12; 1;   else; 0    }
-hour12  { if ampm; hour - 12; else; hour }
+hour12  { if hour == 0 || hour == 12; 12; elseif ampm; hour - 12; else; hour }
 minute  { GETTIME[5] }
 second  { GETTIME[6] }
 


### PR DESCRIPTION
The current hour12 function displays 12 o'clock as 0, but 12 hour time never shows a 0 for the hour, so the function is effectively useless.
This may cause issues for anyone who has code relying on this function, but I would hope it's mostly being used for display purposes anyways?