### PR TITLE
Fix aitalk not resetting if aitalk script is empty

### DIFF
--- a/yaya_base/shiori3.dic
+++ b/yaya_base/shiori3.dic
@@ -849,10 +849,6 @@ SHIORI3FW.RaiseIDEvent
 				SHIORI3FW.Status = 'Run'
 			}
 			SHIORI3FW.LastTalk = _talk[0]
-			if _event == 'OnAITalkNewEvent' {
-				SHIORI3FW.LastAITalk = _talk[0]
-				SHIORI3FW.ResetAITalkInterval()
-			}
 			if 'Surface' !_in_ _event {
 				if SHIORI3FW.RemoveAllTags(_talk[0]) != '' {
 					SHIORI3FW.LastTalkTime = GETSECCOUNT()
@@ -860,6 +856,10 @@ SHIORI3FW.RaiseIDEvent
 			}
 			_talk[0]
 		}
+	}
+	if _event == 'OnAITalkNewEvent' {
+		SHIORI3FW.LastAITalk = _talk[0]
+		SHIORI3FW.ResetAITalkInterval()
 	}
 
 	// reference&PassThru_Ins 変数をクリア


### PR DESCRIPTION
I have a music player ghost with options to only talk when playing music, only talk when NOT playing music, or freely talk. Depending on which mode it is in, and if music is playing, sometimes I have it skip aitalk altogether. As a result, SHIORI3FW.ResetAITalkInterval is never called and SHIORI3FW.IsAITalkComplete is therefore stuck at 1. So, until the ghost is reloaded, it will never activate aitalk again.

This also fixes an issue I have seen in a few ghosts, where having a stray -- can result in the ghost's aitalk sometimes stopping and never restarting. Like so:
```c
if ghostexcount > 0
{
  _randghost = ANY(ghostexlist)
  --
  if _randghost == "Emily"
  {
      "Hi Emily!"
  }
}
```
The above code will return nothing if the ghost Emily is not present, or not picked from the list of open ghosts. This will cause the same issue described above, where aitalk will get stuck. And I have seen code like this in a lot of ghosts.

Well... Perhaps fix is not the right word. The empty response can still be sent, which means no dialogue will be displayed. But, aitalk won't stop activating entirely, so this is sort of a failsafe if anything should go wrong in aitalk.

I've moved the snip of code responsible for resetting aitalk out of the check for if the resulting script was empty. This way, even if the script was empty, it will still reset and work as normal.

I don't know if this will affect anything else? What do you think?