### PR TITLE
Fix aitalk no longer firing at all

### DIFF
--- a/yaya_base/shiori3.dic
+++ b/yaya_base/shiori3.dic
@@ -792,7 +792,7 @@ SHIORI3FW.RaiseIDEvent
 		_event = SHIORI3FW.TranslateEvent(_event)
 	}
 
-	if ! _is_second_change {
+	if _event != 'OnSecondChange' {
 		if ISFUNC('SHIORI3EV.' + _event) {
 			_result_internal = TOSTR(EVAL('SHIORI3EV.' + _event))
 		}


### PR DESCRIPTION
With the current version, aitalk will never fire, because OnSecondChange is used to control aitalk and therefore _is_second_change is always true when it comes to aitalk.
I've reverted the check for the _event variable; now it once again checks to see if the event has changed from OnSecondChange to OnAITalkNewEvent. This seems to have fixed all of the bugs on my end.