### PR TITLE
disable `SHIORI3FW.DebugMode` by default

### DIFF
--- a/yaya_base/shiori3.dic
+++ b/yaya_base/shiori3.dic
@@ -143,7 +143,7 @@ load
 	SHIORI3FW.HWndOld      = (0,0)
 	SHIORI3FW.BalloonHWnd  = (0,0)
 	SHIORI3FW.UniqueID     = ''
-	SHIORI3FW.DebugMode    = 1
+	SHIORI3FW.DebugMode    = 0
 	SHIORI3FW.CanTalkFlag  = 1
 
 	SHIORI3FW.Eventid = ''


### PR DESCRIPTION
I think that `SHIORI3FW.DebugMode` should be disabled by default for security reasons.